### PR TITLE
Add custom autocomplete renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8623,6 +8623,11 @@
       "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
       "dev": true
     },
+    "random-words": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/random-words/-/random-words-1.1.0.tgz",
+      "integrity": "sha512-GyV8PlSmQE08S/RSCjG9Uh0uQaUC7iRpA18PWk9OSnvNCzKQ+B2NxqqN/cYBej4t7dfBWxh10KFBYSiNcg1jlg=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "core-js": "^2.4.1",
     "json-refs": "^3.0.4",
     "libphonenumber-js": "^1.6.8",
+    "random-words": "^1.1.0",
     "redux": "3.7.2",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.19"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,7 @@ import {DevToolsExtension, NgRedux} from '@angular-redux/store';
 import {Actions, JsonFormsState, UISchemaElement} from '@jsonforms/core';
 import { JsonFormsAngularMaterialModule } from '@jsonforms/angular-material';
 import * as AJV from 'ajv';
-import { parsePhoneNumber } from 'libphonenumber-js'
+import { parsePhoneNumber } from 'libphonenumber-js';
 import logger from 'redux-logger';
 
 import { initialState, rootReducer } from './store';
@@ -15,17 +15,23 @@ import schema from './schema';
 import uischema from './uischema';
 
 import { AppComponent } from './app.component';
+import {CustomAutocompleteControlRenderer} from './custom.autocomplete';
+import {MatAutocompleteModule, MatProgressSpinnerModule} from '@angular/material';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    CustomAutocompleteControlRenderer
   ],
   imports: [
     BrowserModule,
     JsonFormsAngularMaterialModule,
+    MatAutocompleteModule,
+    MatProgressSpinnerModule
   ],
   schemas: [],
   providers: [],
+  entryComponents: [CustomAutocompleteControlRenderer],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/src/app/custom.autocomplete.ts
+++ b/src/app/custom.autocomplete.ts
@@ -1,0 +1,62 @@
+import * as randomWords from 'random-words';
+import {debounceTime, finalize, tap} from 'rxjs/operators';
+import {switchMap} from 'rxjs/operators/switchMap';
+import {delay} from 'rxjs/operators/delay';
+import {of} from 'rxjs/observable/of';
+import {AutocompleteControlRenderer} from '@jsonforms/angular-material';
+import {Observable} from 'rxjs/Observable';
+import {Component} from '@angular/core';
+
+const words: string[] = randomWords(1000);
+
+const fetchSuggestions = (input: string): Observable<string[]> => {
+  const filtered: string[] = words.filter(word => word.startsWith(input));
+  return of(filtered).pipe(delay(1000));
+};
+
+@Component({
+  selector: 'jsonforms-custom-autocomplete',
+  template: `
+        <mat-form-field fxFlex>
+            <mat-label>{{ label }}</mat-label>
+            <input
+                matInput
+                type="text"
+                (input)="onChange($event)"
+                placeholder="{{ description }}"
+                [id]="id"
+                [formControl]="form"
+                [matAutocomplete]="auto"
+            >
+            <mat-autocomplete
+                autoActiveFirstOption #auto="matAutocomplete" (optionSelected)="onSelect($event)">
+              <mat-option *ngIf="isLoading" class="is-loading"><mat-spinner diameter="30"></mat-spinner></mat-option>
+              <ng-container *ngIf="!isLoading">
+                <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
+                    {{ option }}
+                </mat-option>
+              </ng-container>
+            </mat-autocomplete>
+            <mat-error>{{ error }}</mat-error>
+        </mat-form-field>
+    `
+})
+export class CustomAutocompleteControlRenderer extends AutocompleteControlRenderer {
+
+  isLoading: boolean;
+
+  ngOnInit() {
+    super.ngOnInit();
+    this.form.valueChanges
+      .pipe(
+        debounceTime(300),
+        tap(() => this.isLoading = true),
+        switchMap(value => fetchSuggestions(value)
+          .pipe(
+            finalize(() => this.isLoading = false)
+          )
+        )
+      )
+      .subscribe((options: string[]) => this.options = options);
+  }
+}

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,16 +1,22 @@
-import { combineReducers, Reducer } from 'redux';
-import {
-  jsonformsReducer,
-  JsonFormsState,
-} from '@jsonforms/core';
+import {combineReducers, Reducer} from 'redux';
+import {and, jsonformsReducer, JsonFormsState, rankWith, schemaTypeIs, scopeEndsWith, Tester,} from '@jsonforms/core';
 
-import { angularMaterialRenderers } from '@jsonforms/angular-material';
+import {angularMaterialRenderers} from '@jsonforms/angular-material';
+import {CustomAutocompleteControlRenderer} from './custom.autocomplete';
 
 export const rootReducer: Reducer<JsonFormsState> = combineReducers({ jsonforms: jsonformsReducer() });
 
+const departmentTester: Tester = and(
+  schemaTypeIs('string'),
+  scopeEndsWith('department')
+);
+
 export const initialState: any = {
   jsonforms: {
-    renderers: angularMaterialRenderers,
+    renderers: [
+      ...angularMaterialRenderers,
+      { tester: rankWith(5, departmentTester), renderer: CustomAutocompleteControlRenderer }
+    ],
     fields: [],
   }
 };


### PR DESCRIPTION
The new, custom renderer is triggered for the `department` property. The suggestions are randomly generated words. The template of the default auto complete renderer has been copied as extended with a loading spinner. We might want to think of including that in the default renderer.